### PR TITLE
Fix Windows CI and export symbols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,20 +50,24 @@ build_script:
   - mkdir build
   - cd build
   - echo "Call QMake..."
-  - qmake.exe ..\JKQtPlotterBuildAllExamples.pro
+  - qmake.exe CONFIG+=%CONFIGURATION% ..\JKQtPlotterBuildAllExamples.pro
   - echo "Build..."
   - call %MAKETOOL%
   - cd ..
 
 artifacts:
-   - path: build\lib\release\*.a
-     name: lib %QTVER%%QTABI%
-   - path: build\lib\release\*.lib
-     name: lib %QTVER%%QTABI%
-   - path: build\lib\release\*.dll
+   - path: build\staticlib\**\*.a
+     name: staticlib %QTVER%%QTABI%
+   - path: build\sharedlib\**\*.a
+     name: sharedlib %QTVER%%QTABI%
+   - path: build\staticlib\**\*.lib
+     name: staticlib %QTVER%%QTABI%
+   - path: build\sharedlib\**\*.lib
+     name: sharedlib %QTVER%%QTABI%
+   - path: build\sharedlib\**\*.dll
      name: dll %QTVER%%QTABI%
-   - path: build\test\**\*.exe
-     name: Test %QTVER%%QTABI%
+   - path: build\examples\**\*.exe
+     name: Examples %QTVER%%QTABI%
 
 
 # # remote desktop connection on init

--- a/sharedlib/jkqtfastplotterlib_sharedlib.pro
+++ b/sharedlib/jkqtfastplotterlib_sharedlib.pro
@@ -4,4 +4,9 @@ CONFIG (debug, debug|release): TARGET = jkqtfastplotterlib_debug
 TEMPLATE = lib
 CONFIG+=dll
 
+win32 {
+    DEFINES += LIB_IN_DLL
+    DEFINES += LIB_EXPORT_LIBRARY
+}
+
 include(../lib/jkqtfastplotter.pri)

--- a/sharedlib/jkqtmathtextlib_sharedlib.pro
+++ b/sharedlib/jkqtmathtextlib_sharedlib.pro
@@ -4,4 +4,9 @@ CONFIG (debug, debug|release): TARGET = jkqtmathtextlib_debug
 TEMPLATE = lib
 CONFIG+=dll
 
+win32 {
+    DEFINES += LIB_IN_DLL
+    DEFINES += LIB_EXPORT_LIBRARY
+}
+
 include(../lib/jkqtmathtext.pri)

--- a/sharedlib/jkqtplotterlib_sharedlib.pro
+++ b/sharedlib/jkqtplotterlib_sharedlib.pro
@@ -4,4 +4,9 @@ CONFIG (debug, debug|release): TARGET = jkqtplotterlib_debug
 TEMPLATE = lib
 CONFIG += dll
 
+win32 {
+    DEFINES += LIB_IN_DLL
+    DEFINES += LIB_EXPORT_LIBRARY
+}
+
 include(../lib/jkqtplotter.pri)


### PR DESCRIPTION
After recent commits it has build errors on my OS that maybe are related to path limit on Windows, but it builds correctly in AppVeyor workers.