### PR TITLE
compiles for Qt5 in KDE Neon 5.16.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if (NOT CMAKE_INSTALL_INCLUDEDIR)
 endif()
 
 
-find_package(Qt5 5.0 REQUIRED Core Gui Widgets PrintSupport Svg Xml OpenGl)
+find_package(Qt5 5.0 REQUIRED Core Gui Widgets PrintSupport Svg Xml OpenGL)
 
 
 

--- a/lib/jkqtcommon/jkqtphighrestimer.h
+++ b/lib/jkqtcommon/jkqtphighrestimer.h
@@ -132,12 +132,11 @@ class JKQTCOMMON_LIB_EXPORT JKQTPHighResTimer {
     #ifdef __WINDOWS__
       /** \brief internal: time stamp of the last call of start() */
       LARGE_INTEGER last;
-
-      /** \brief internal: timer frequency */
-      double freq;
     #else
       struct timeval last;
     #endif
+      /** \brief internal: timer frequency */
+      double freq;
     public:
         /** \brief class constructor. */
         JKQTPHighResTimer();


### PR DESCRIPTION
A couple of fixes to make it work on Linux (KDE Neon 5.16.4) and Qt5. Not tested on any other platform.