### PR TITLE
qt5.9 support

### DIFF
--- a/lib/jkqtplotter/jkqtpbaseplotterstyle.cpp
+++ b/lib/jkqtplotter/jkqtpbaseplotterstyle.cpp
@@ -103,8 +103,8 @@ void JKQTBasePlotterStyle::loadSettings(const QSettings &settings, const QString
             QString kk=k;
             kk.remove(0, start.size());
             QString num="";
-            while (kk.front().isDigit()) {
-                num+=kk.front();
+            while (kk.at(0).isDigit()) {
+                num+=kk.at(0);
                 kk.remove(0, 1);
             }
             bool ok=false;

--- a/lib/jkqtplotter/jkqtplotterstyle.cpp
+++ b/lib/jkqtplotter/jkqtplotterstyle.cpp
@@ -84,8 +84,8 @@ void JKQTPlotterStyle::loadSettings(const QSettings &settings, const QString &gr
             QString kk=k;
             kk.remove(0, start.size());
             QString num="";
-            while (kk.front().isDigit()) {
-                num+=kk.front();
+            while (kk.at(0).isDigit()) {
+                num+=kk.at(0);
                 kk.remove(0, 1);
             }
             bool ok=false;


### PR DESCRIPTION
the .front() function is introduced in qt5.10, 
the .at(0) has the same behaviour and is present in qt5.9 which is the ubuntu 18.04 default. 