### PR TITLE
Add project() into CMakeLists.txt to fix a warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # Find includes in the build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+project(JKQtPlotter VERSION 1.0.0)
+
 # Common Includes for JKQtPlotter
 include(jkqtplotter_common_include)
 


### PR DESCRIPTION
Previously it was giving the following warning:

```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Also by giving it a version, the ${PROJECT_VERSION} variable will be
properly set, which fixes the following error:

```
CMake Error at .../miniconda3/envs/qt/share/cmake-3.15/Modules/WriteBasicConfigVersionFile.cmake:43 (message):
  No VERSION specified for WRITE_BASIC_CONFIG_VERSION_FILE()
Call Stack (most recent call first):
  .../miniconda3/envs/qt/share/cmake-3.15/Modules/CMakePackageConfigHelpers.cmake:225 (write_basic_config_version_file)
  lib/jkqtcommon/CMakeLists.txt:85 (write_basic_package_version_file)
```

Fixes #20.