### PR TITLE
Fix the name of jkqtplotter_lib_properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include(jkqtplotter_common_include)
 
 # Project Name and Version
-include(JKQtPlotter_LIB_properties)
+include(jkqtplotter_lib_properties)
 
 # CMake options with default values and description texts
 include(jkqtplotter_cmake_options)


### PR DESCRIPTION
Previously it could not find the cmake file and giving an error:
```
CMake Error at CMakeLists.txt:15 (include):
  include could not find load file:

    JKQtPlotter_LIB_properties
```
Fixes #20.