### PR TITLE
Improve Travis: test on Linux and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,16 @@ matrix:
       os: osx
     - compiler: clang
       os: linux
+      addons:
+        apt:
+          packages:
+            - libglu1-mesa-dev
     - compiler: gcc
       os: linux
+      addons:
+        apt:
+          packages:
+            - libglu1-mesa-dev
 
 install:
   - source ci/install_travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,65 @@
+language: cpp
 sudo: false
+compiler:
+  - gcc
+  - clang
+os:
+  - linux
+  - osx
 dist: xenial
+osx_image: xcode7.3
 
-branches:
-  only:
-    - master
+matrix:
+  exclude:
+    - compiler: clang
+    - os: osx
+  include:
+    - env: BUILD_DOXYGEN="yes"
+      compiler: gcc
+      os: linux
+      addons:
+        apt:
+          packages:
+            - doxygen
+            - doxygen-doc
+            - doxygen-latex
+            - doxygen-gui
+            - graphviz
+      install:
+        - pwd
+        - doxygen --version
+        ############################################################################
+        # All the dependencies are installed in ${TRAVIS_BUILD_DIR}/deps/
+        ############################################################################
+        - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+        - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+        ############################################################################
+        # Install a recent Doxygen
+        ############################################################################
+        - DOXYGEN_URL="http://doxygen.nl/files/doxygen-1.8.16.linux.bin.tar.gz"
+        - mkdir doxygen
+        - travis_retry wget -O - ${DOXYGEN_URL} | tar --strip-components=1 -xz -C doxygen
+        - export PATH=${DEPS_DIR}/doxygen/bin:${PATH}
+        - doxygen --version
+      script:
+        - pwd
+        - cd ${TRAVIS_BUILD_DIR}
+        - cd doc
+        - doxygen --version
+        - doxygen Doxyfile
+        - echo "" > html/.nojekyll
 
-# Install dependencies
-addons:
-  apt:
-    packages:
-      - doxygen
-      - doxygen-doc
-      - doxygen-latex
-      - doxygen-gui
-      - graphviz
- 
-    
 install:
-  - pwd
-  - doxygen --version
-  ############################################################################
-  # All the dependencies are installed in ${TRAVIS_BUILD_DIR}/deps/
-  ############################################################################
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
-  ############################################################################
-  # Install a recent Doxygen
-  ############################################################################
-  - DOXYGEN_URL="http://doxygen.nl/files/doxygen-1.8.16.linux.bin.tar.gz"
-  - mkdir doxygen 
-  - travis_retry wget -O - ${DOXYGEN_URL} | tar --strip-components=1 -xz -C doxygen
-  - export PATH=${DEPS_DIR}/doxygen/bin:${PATH}
-  - doxygen --version
+  - cmake --version
 
 script:
-  - pwd
-  - cd ${TRAVIS_BUILD_DIR}
-  - cd doc
-  - doxygen --version
-  - doxygen Doxyfile
-  - echo "" > html/.nojekyll
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/ext ..
+  - cmake --build . --target install
+
+notifications:
+  email: false
 
 deploy:
   provider: pages
@@ -50,3 +70,4 @@ deploy:
   github_token: $GH_REPO_TOKEN
   on:
     branch: master
+    condition: $BUILD_DOXYGEN = yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ matrix:
         - echo "" > html/.nojekyll
     - compiler: clang
       os: osx
-    - compiler: gcc
-      os: osx
     - compiler: clang
       os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,10 @@ matrix:
       os: linux
 
 install:
-  - cmake --version
+  - source ci/install_travis.sh
 
 script:
-  - mkdir build
-  - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/ext ..
-  - cmake --build . --target install
+  - ci/test_travis.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - linux
   - osx
 dist: xenial
-osx_image: xcode7.3
+osx_image: xcode8.3
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,13 @@ osx_image: xcode7.3
 
 matrix:
   exclude:
+    # Disable all automatic entries in the test matrix
     - compiler: clang
+    - compiler: gcc
     - os: osx
+    - os: linux
   include:
+    # Explicitly add tests that we want to run
     - env: BUILD_DOXYGEN="yes"
       compiler: gcc
       os: linux
@@ -48,6 +52,14 @@ matrix:
         - doxygen --version
         - doxygen Doxyfile
         - echo "" > html/.nojekyll
+    - compiler: clang
+      os: osx
+    - compiler: gcc
+      os: osx
+    - compiler: clang
+      os: linux
+    - compiler: gcc
+      os: linux
 
 install:
   - cmake --version

--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+# Echo each command
+set -x
+
+export SOURCE_DIR=`pwd`
+export our_install_dir="$HOME/our_usr"
+
+if [[ ! -d $HOME/conda_root/pkgs ]]; then
+    rm -rf $HOME/conda_root
+    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+    else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    fi
+    bash miniconda.sh -b -p $HOME/conda_root
+fi
+export PATH="$HOME/conda_root/bin:$PATH"
+conda config --set always_yes yes --set changeps1 no
+conda config --add channels conda-forge --force
+# Useful for debugging any issues with conda
+conda info -a
+
+conda_pkgs="qt cmake"
+
+conda create -q -p $our_install_dir ${conda_pkgs}
+source activate $our_install_dir
+
+cd $SOURCE_DIR;
+
+# Since this script is getting sourced, remove error on exit
+set +e
+set +x

--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -26,10 +26,12 @@ conda info -a
 conda_pkgs="qt cmake"
 
 conda create -q -p $our_install_dir ${conda_pkgs}
-source activate $our_install_dir
-
-cd $SOURCE_DIR;
 
 # Since this script is getting sourced, remove error on exit
 set +e
 set +x
+
+source activate $our_install_dir
+
+cd $SOURCE_DIR;
+

--- a/ci/test_travis.sh
+++ b/ci/test_travis.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+# Echo each command
+set -x
+
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+cmake --build . --target install


### PR DESCRIPTION
Keep the Doxygen run as before, but also test building and installing
using cmake on Linux and macOS with both gcc and clang.