### PR TITLE
Set the proper RPATH for installed libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # Find includes in the build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+if(NOT APPLE)
+    set(CMAKE_INSTALL_RPATH $ORIGIN)
+endif()
+
 # Common Includes for JKQtPlotter
 include(jkqtplotter_common_include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # Find includes in the build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(NOT APPLE)
-    set(CMAKE_INSTALL_RPATH $ORIGIN)
-endif()
-
 # Common Includes for JKQtPlotter
 include(jkqtplotter_common_include)
 

--- a/cmake/jkqtplotter_common_compilersettings.cmake
+++ b/cmake/jkqtplotter_common_compilersettings.cmake
@@ -16,3 +16,7 @@ elseif(MSVC)
   # have reference type and must not be parenthesized
   add_definitions(/D_CRT_NO_VA_START_VALIDATION)
 endif()
+
+if(NOT APPLE)
+    set(CMAKE_INSTALL_RPATH $ORIGIN)
+endif()


### PR DESCRIPTION
Fixes #25. Now everything works on Linux out of the box.