### PR TITLE
Skip plotting negative or zero values in log plots

### DIFF
--- a/lib/jkqtfastplotter/jkqtfastplotter.h
+++ b/lib/jkqtfastplotter/jkqtfastplotter.h
@@ -22,6 +22,7 @@
 #ifndef JKQTFASTPLOTTER_H
 #define JKQTFASTPLOTTER_H
 
+#include "jkqtcommon/jkqtpmathtools.h"
 #include "jkqtfastplotter_imexport.h"
 #include <QWidget>
 #include <QVector>
@@ -397,7 +398,7 @@ class JKQTFASTPLOTTER_LIB_EXPORT JKQTFastPlotter : public QGLWidget {
         /** \brief return x-pixel coordinate from x coordinate */
         inline double x2p(double x) {
             if (xAxisLog) {
-                if (x<0) return xOffset+log(xMin/10.0)/log(10.0)*xScale;
+                if (x<0) return JKQTP_NAN;
                 return xOffset+log(x)/log(10.0)*xScale;
             } else {
                 return xOffset+x*xScale;

--- a/lib/jkqtplotter/jkqtpcoordinateaxes.h
+++ b/lib/jkqtplotter/jkqtpcoordinateaxes.h
@@ -175,7 +175,7 @@ class JKQTPLOTTER_LIB_EXPORT JKQTPCoordinateAxis: public QObject {
         inline double x2p(double x) const {
             double r=0;
             if (logAxis) {
-                if (x<=0) r= offset+scaleSign*log(axismin)/log(logAxisBase)*scale;
+                if (x<=0) r= JKQTP_NAN;
                 else r= offset+scaleSign*log(x)/log(logAxisBase)*scale;
             } else {
                 r= offset+scaleSign*x*scale;


### PR DESCRIPTION
Currently if you plot negative or zero value in a log plot, it will be plotted a the axis line. That produces an incorrect slope in the graph. The way to solve this is to skip such values, as Matplotlib and other plotting packages do. This PR skips such values.

There is still another bug: when a value is skipped, the line still connects the remaining values. That is also incorrect, one should break the line where a value was skipped.