### PR TITLE
Bug: JKMathParser exception return local variable

### DIFF
--- a/lib/jkqtcommon/jkqtpmathparser.cpp
+++ b/lib/jkqtcommon/jkqtpmathparser.cpp
@@ -1889,7 +1889,7 @@ std::string JKQTPMathParser::jkmpException::getMessage() const {
 }
 
 const char *JKQTPMathParser::jkmpException::what() const noexcept {
-    return getMessage().c_str();
+    return errormessage.c_str();
 }
 
 JKQTPMathParser *JKQTPMathParser::jkmpNode::getParser(){ return parser; }


### PR DESCRIPTION
Fix the what() function which returned a pointer to a local variable.