### PR TITLE
Replace deprecated Qt printer and list related functions.

### DIFF
--- a/lib/jkqtplotter/gui/jkqtpenhancedtableview.cpp
+++ b/lib/jkqtplotter/gui/jkqtpenhancedtableview.cpp
@@ -165,9 +165,9 @@ void JKQTPEnhancedTableView::copySelectionToExcel(int copyrole, bool storeHead)
                 if (r<rowmin) rowmin=r;
             }
         }
-        QList<int> rowlist=QList<int>::fromSet(rows);
+        QList<int> rowlist=QList<int>(rows.begin(), rows.end());
         std::sort(rowlist.begin(), rowlist.end());
-        QList<int> collist=QList<int>::fromSet(cols);
+        QList<int> collist=QList<int>(cols.begin(), cols.end());
         std::sort(collist.begin(), collist.end());
         int rowcnt=rowlist.size();
         int colcnt=collist.size();
@@ -284,9 +284,9 @@ void JKQTPEnhancedTableView::copySelectionToCSV(int copyrole, bool storeHead, co
                 if (r<rowmin) rowmin=r;
             }
         }
-        QList<int> rowlist=QList<int>::fromSet(rows);
+        QList<int> rowlist=QList<int>(rows.begin(), rows.end());
         std::sort(rowlist.begin(), rowlist.end());
-        QList<int> collist=QList<int>::fromSet(cols);
+        QList<int> collist=QList<int>(cols.begin(), cols.end());
         std::sort(collist.begin(), collist.end());
         int rowcnt=rowlist.size();
         int colcnt=collist.size();
@@ -447,10 +447,10 @@ void JKQTPEnhancedTableView::print(QPrinter *printer, bool onePageWide, bool one
      /*if (maxWidth*scale>p->pageRect().width()) scale=p->pageRect().width()/maxWidth;
      if (maxHeight*scale>p->pageRect().height()) scale=p->pageRect().height()/maxHeight;*/
      if (onePageWide) {
-         if (totalWidth>p->pageRect().width()) scale=p->pageRect().width()/totalWidth;
+         if (totalWidth>p->pageLayout().paintRectPixels(p->resolution()).width()) scale=p->pageLayout().paintRectPixels(p->resolution()).width()/totalWidth;
      }
      if (onePageHigh) {
-         if (totalHeight>p->pageRect().height()) scale=qMin(scale, p->pageRect().height()/totalHeight);
+         if (totalHeight>p->pageLayout().paintRectPixels(p->resolution()).height()) scale=qMin(scale, p->pageLayout().paintRectPixels(p->resolution()).height()/totalHeight);
      }
 
      //qDebug()<<scale;
@@ -467,7 +467,7 @@ void JKQTPEnhancedTableView::print(QPrinter *printer, bool onePageWide, bool one
          if (!onePageWide) {
              for (int c=0; c<cols; c++) {
                  double cw=columnWidth(c);
-                 if (x+cw>p->pageRect().width()/scale) {
+                 if (x+cw>p->pageLayout().paintRectPixels(p->resolution()).width()/scale) {
                      pagesWide++;
                      x=0;
                      pageCols<<c;
@@ -483,7 +483,7 @@ void JKQTPEnhancedTableView::print(QPrinter *printer, bool onePageWide, bool one
          if (!onePageHigh) {
              for (int r=0; r<rows; r++) {
                  double rh=rowHeight(r);
-                 if (y+rh>p->pageRect().height()/scale) {
+                 if (y+rh>p->pageLayout().paintRectPixels(p->resolution()).height()/scale) {
                      pagesHigh++;
                      pageRows<<r;
                      y=hhh;

--- a/lib/jkqtplotter/jkqtpbaseplotter.cpp
+++ b/lib/jkqtplotter/jkqtpbaseplotter.cpp
@@ -1485,12 +1485,12 @@ void JKQTBasePlotter::print(QPrinter* printer, bool displayPreview) {
         delete dialog;
     }
 
-    p->setPageMargins(10,10,10,10,QPrinter::Millimeter);
+    p->setPageMargins(QMarginsF(10,10,10,10),QPageLayout::Millimeter);
 
     if (widgetWidth>widgetHeight) {
-        p->setOrientation(QPrinter::Landscape);
+        p->setPageOrientation(QPageLayout::Landscape);
     } else {
-        p->setOrientation(QPrinter::Portrait);
+        p->setPageOrientation(QPageLayout::Portrait);
     }
 
     printpreviewNew(p, false, -1.0, -1.0, displayPreview);
@@ -1554,14 +1554,14 @@ bool JKQTBasePlotter::printpreviewNew(QPaintDevice* paintDevice, bool setAbsolut
         printer->setColorMode(QPrinter::Color);
         printer->setOutputFormat(QPrinter::PdfFormat);
         printer->setResolution(svg->logicalDpiX());
-        printer->setPageMargins(0,0,0,0,QPrinter::Millimeter);
+        printer->setPageMargins(QMarginsF(), QPageLayout::Millimeter);
         printer->setColorMode(QPrinter::Color);
         delPrinter=true;
     } else if (!printer) {
         printer=new QPrinter();
         printer->setOutputFormat(QPrinter::PdfFormat);
         printer->setResolution(paintDevice->logicalDpiX());
-        printer->setPageMargins(0,0,0,0,QPrinter::Millimeter);
+        printer->setPageMargins(QMarginsF(), QPageLayout::Millimeter);
         printer->setColorMode(QPrinter::Color);
         delPrinter=true;
     }
@@ -1931,8 +1931,8 @@ void JKQTBasePlotter::printpreviewPaintRequested(QPrinter* printer) {
         qDebug()<<"set printing abs. size to "<<QSizeF(printSizeX_Millimeter, printSizeY_Millimeter)<<" mm^2";
 #endif
         //printer->setPaperSize(QPrinter::Custom);
-        printer->setOrientation(QPrinter::Portrait);
-        printer->setPaperSize(QSizeF(printSizeX_Millimeter, printSizeY_Millimeter), QPrinter::Millimeter);
+        printer->setPageOrientation(QPageLayout::Portrait);
+        printer->setPageSize(QPageSize(QSizeF(printSizeX_Millimeter, printSizeY_Millimeter), QPageSize::Millimeter));
         if (!gridPrinting) widgetHeight=jkqtp_roundTo<int>(widgetWidth*printSizeY_Millimeter/printSizeX_Millimeter);
 
     }
@@ -1969,7 +1969,7 @@ void JKQTBasePlotter::printpreviewPaintRequested(QPrinter* printer) {
     qDebug()<<"x-axis label fontsize = "<<xAxis->getLabelFontSize()<<" pt";
     qDebug()<<"y-axis label fontsize = "<<yAxis->getLabelFontSize()<<" pt";
 #endif
-    gridPaint(painter, printer->pageRect().size(), printScaleToPagesize, printScaleToPagesize);
+    gridPaint(painter, printer->pageLayout().paintRectPixels(printer->resolution()).size(), printScaleToPagesize, printScaleToPagesize);
     painter.end();
     widgetWidth=oldWidgetWidth;
     widgetHeight=oldWidgetHeight;
@@ -2017,8 +2017,8 @@ void JKQTBasePlotter::printpreviewPaintRequestedNew(QPaintDevice *paintDevice)
         qDebug()<<"set printing abs. size to "<<QSizeF(printSizeX_Millimeter, printSizeY_Millimeter)<<" mm^2";
 #endif
         if (printer) {
-            printer->setOrientation(QPrinter::Portrait);
-            printer->setPaperSize(QSizeF(printSizeX_Millimeter, printSizeY_Millimeter), QPrinter::Millimeter);
+            printer->setPageOrientation(QPageLayout::Portrait);
+            printer->setPageSize(QPageSize(QSizeF(printSizeX_Millimeter, printSizeY_Millimeter), QPageSize::Millimeter));
         } else if (svg) {
             QRectF siz=QRectF(0,0,printSizeX_Millimeter,printSizeY_Millimeter);
             svg->setSize(QSizeF(ceil(siz.width()*svg->resolution()/25.4), ceil(siz.height()*svg->resolution()/25.4)).toSize());
@@ -2069,7 +2069,7 @@ void JKQTBasePlotter::printpreviewPaintRequestedNew(QPaintDevice *paintDevice)
     qDebug()<<"x-axis label fontsize = "<<xAxis->getLabelFontSize()<<" pt";
     qDebug()<<"y-axis label fontsize = "<<yAxis->getLabelFontSize()<<" pt";
 #endif
-    if (printer) gridPaint(painter, printer->pageRect().size(), printScaleToPagesize, printScaleToPagesize);
+    if (printer) gridPaint(painter, printer->pageLayout().paintRectPixels(printer->resolution()).size(), printScaleToPagesize, printScaleToPagesize);
     else if (svg) gridPaint(painter, svg->size(), printScaleToPagesize, printScaleToPagesize);
     else gridPaint(painter, QSizeF(paintDevice->width(), paintDevice->height()), printScaleToPagesize, printScaleToPagesize);
     painter.end();
@@ -3577,14 +3577,14 @@ void JKQTBasePlotter::saveAsPDF(const QString& filename, bool displayPreview) {
             doLandscape=gridPrintingSize.width()>gridPrintingSize.height();
         }
         if (doLandscape) {
-            printer->setOrientation(QPrinter::Landscape);
+            printer->setPageOrientation(QPageLayout::Landscape);
         } else {
-            printer->setOrientation(QPrinter::Portrait);
+            printer->setPageOrientation(QPageLayout::Portrait);
         }
         printer->setOutputFormat(QPrinter::PdfFormat);
         printer->setColorMode(QPrinter::Color);
         printer->setOutputFileName(fn);
-        printer->setPageMargins(0,0,0,0,QPrinter::Millimeter);
+        printer->setPageMargins(QMarginsF(0,0,0,0),QPageLayout::Millimeter);
         printer->setColorMode(QPrinter::Color);
         printpreviewNew(printer, true, -1.0, -1.0, displayPreview);
         delete printer;


### PR DESCRIPTION
Swaps various functions related to QPrinter and QList with newer variants.

Raises minimum Qt version to at least 5.3. So perhaps this patch should be stalled if Qt 5.0 compatibility is important. I did not yet try compiling with Qt 6, but this patch is necessary for that.

Tested with Qt 5.15. Generally everything seemed to work, but I didn't do extensive testing.