### PR TITLE
Enable high-dpi support for plots

### DIFF
--- a/lib/jkqtplotter/jkqtplotter.cpp
+++ b/lib/jkqtplotter/jkqtplotter.cpp
@@ -1236,8 +1236,9 @@ void JKQTPlotter::resizeEvent(QResizeEvent *event) {
 
 void JKQTPlotter::delayedResizeEvent()
 {
-    int plotImageWidth=width();
-    int plotImageHeight=height();
+    qreal dpr = devicePixelRatioF();
+    int plotImageWidth=width() * dpr;
+    int plotImageHeight=height() * dpr;
 
     plotImageHeight=plotImageHeight-getPlotYOffset();
     //qDebug()<<"resize: "<<plotImageWidth<<" x "<<plotImageHeight<<std::endl;
@@ -1245,6 +1246,8 @@ void JKQTPlotter::delayedResizeEvent()
     if (plotImageWidth != image.width() || plotImageHeight != image.height()) {
 
         QImage newImage(QSize(plotImageWidth, plotImageHeight), QImage::Format_ARGB32);
+        newImage.setDevicePixelRatio(dpr);
+
         image=newImage;
         sizeChanged=true;
     }


### PR DESCRIPTION
This PR enables higher resolution plots for high-dpi devices that do not use a 1.0 device pixel ratio.  The issue is described well here:

https://stackoverflow.com/questions/42011410/qt-drawing-high-dpi-qpixmaps

The problem is that JKQtPlotter, like this example, is drawing to an offscreen QImage based on the "size" of the widget.  However, a high-dpi display like a Mac Retina display will report half the actual size (e.g. 400x400 instead of 800x800) since these display units are given at the non-high-dpi scale.

Before:

<img width="352" alt="before" src="https://user-images.githubusercontent.com/1693349/129981241-2aae86d1-9ccb-48e8-b9ac-5f446ba12397.png">

After:

<img width="354" alt="after" src="https://user-images.githubusercontent.com/1693349/129981252-5a0da36a-542f-4a50-8ea6-03d0dfeb0c01.png">

I can't say that I've done very extensive testing with these changes, but they have been suitable for my uses.
