### PR TITLE
fixed https://github.com/jkriege2/JKQtPlotter/issues/113: bug in CMak…

### DIFF
--- a/lib/jkqtplotter/CMakeLists.txt
+++ b/lib/jkqtplotter/CMakeLists.txt
@@ -307,7 +307,7 @@ if(JKQtPlotter_BUILD_STATIC_LIBS)
                                 DESTINATION lib/cmake  )
 endif(JKQtPlotter_BUILD_STATIC_LIBS)
 
-install(FILES ${HEADERS}
+install(FILES ${HEADERS_BASE}
 		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${libIncludeSubdir}
 		COMPONENT Headers)
 


### PR DESCRIPTION
…e install()-commmand for jkqtplotter (some headers were missing)