### PR TITLE
Add-qt5.12.12-compatibility

### DIFF
--- a/examples/libexampletools/jkqtpexampleapplication.h
+++ b/examples/libexampletools/jkqtpexampleapplication.h
@@ -41,11 +41,10 @@ protected:
         std::function<void(void)> f;
         std::function<JKQTPlotter*(void)> plotf;
         JKQTPlotter* p;
-        inline Data() {};
         inline Data(const std::function<void(void)>& f_):
             type(FunctorType), f(f_), plotf(), p(nullptr)
         {}
-        inline Data(JKQTPlotter* p_):
+        inline Data(JKQTPlotter* p_=nullptr):
             type(PlotterType), f(), plotf(), p(p_)
         {}
         inline Data(std::function<JKQTPlotter*(void)> p_):

--- a/examples/libexampletools/jkqtpexampleapplication.h
+++ b/examples/libexampletools/jkqtpexampleapplication.h
@@ -41,6 +41,7 @@ protected:
         std::function<void(void)> f;
         std::function<JKQTPlotter*(void)> plotf;
         JKQTPlotter* p;
+        inline Data() {};
         inline Data(const std::function<void(void)>& f_):
             type(FunctorType), f(f_), plotf(), p(nullptr)
         {}

--- a/lib/jkqtcommon/jkqtpmathtools.h
+++ b/lib/jkqtcommon/jkqtpmathtools.h
@@ -664,7 +664,10 @@ JKQTCOMMON_LIB_EXPORT void jkqtp_estimateFraction(double input, int &sign, uint6
     */
 template <class T>
 inline T jkqtp_reversed(const T& l) {
-    return T(l.rbegin(), l.rend());
+    T reversed_l;
+    reversed_l.reserve(l.size());
+    std::reverse_copy(l.begin(), l.end(), std::back_inserter(reversed_l));
+    return reversed_l;
 }
 
 /*! \brief can be used to build a hash-values from several hash-values

--- a/tools/jkqtplotter_doc_imagegenerator/jkqtplotter_doc_imagegenerator.cpp
+++ b/tools/jkqtplotter_doc_imagegenerator/jkqtplotter_doc_imagegenerator.cpp
@@ -534,7 +534,7 @@ void doListStyles(const QDir& outputDir, const QStringList& doctomodify, int ico
         shtml<<"<table>\n  <tr>\n    <th>Style-file\n    <th>Screenshot\n    <th>Symbols\n";
         auto files=dir.entryList();
         if (files.indexOf("default.ini")>=0) {
-            files.swapItemsAt(0,files.indexOf("default.ini"));
+            qSwap(files[0], files[files.indexOf("default.ini")]);
         }
         for (auto& f: files) {
             qDebug()<<"plotting example for style "<<f;


### PR DESCRIPTION
I'm not sure if the modification in `examples\libexampletools\jkqtpexampleapplication.h` is  correctly, but now it doesn't report errors.