### PR TITLE
addGraph function return value fixed

### DIFF
--- a/lib/jkqtplotter/jkqtplotter.h
+++ b/lib/jkqtplotter/jkqtplotter.h
@@ -781,7 +781,7 @@ class JKQTPLOTTER_LIB_EXPORT JKQTPlotter: public QWidget {
         inline void clearGraphs(bool deleteGraphs=true) { plotter->clearGraphs(deleteGraphs); }
 
         /** \copydoc JKQTBasePlotter::addGraph()   */
-        inline void addGraph(JKQTPPlotElement* gr) { plotter->addGraph(gr); }
+        inline size_t addGraph(JKQTPPlotElement* gr) { return plotter->addGraph(gr); }
         /** \copydoc JKQTBasePlotter::addGraphOnTop()   */
         inline void addGraphOnTop(JKQTPPlotElement* gr) { plotter->addGraphOnTop(gr); }
         /** \copydoc JKQTBasePlotter::addGraphAtBottom()   */


### PR DESCRIPTION
Despite basePlotter returning the graph id, Plotter does not pass it to the caller, so I changed it to do so. 
For upcoming actions, it is important to have the identity of the added graph. The graph id can't be retrieved any easier than this.
It is necessary to preserve backward compatibility with v4.0.3. 