### PR TITLE
Added explicit destructor to JKQTPXYLineGraph

### DIFF
--- a/lib/jkqtplotter/graphs/jkqtplines.cpp
+++ b/lib/jkqtplotter/graphs/jkqtplines.cpp
@@ -48,6 +48,8 @@ JKQTPXYLineGraph::JKQTPXYLineGraph(JKQTPlotter* parent):
 {
 }
 
+JKQTPXYLineGraph::~JKQTPXYLineGraph() = default;
+
 JKQTPXYLineGraph::JKQTPXYLineGraph(JKQTBasePlotter* parent):
     JKQTPXYGraph(parent),
     drawLine(true),

--- a/lib/jkqtplotter/graphs/jkqtplines.h
+++ b/lib/jkqtplotter/graphs/jkqtplines.h
@@ -65,6 +65,7 @@ class JKQTPLOTTER_LIB_EXPORT JKQTPXYLineGraph: public JKQTPXYGraph, public JKQTP
         explicit JKQTPXYLineGraph(JKQTBasePlotter* parent=nullptr);
         /** \brief class constructor */
         JKQTPXYLineGraph(JKQTPlotter* parent);
+	virtual ~JKQTPXYLineGraph();
 
         /** \brief plots the graph to the plotter object specified as parent */
         virtual void draw(JKQTPEnhancedPainter& painter) override;


### PR DESCRIPTION
What the name says.  Specifically when building on mingw-w64 with -flto enabled, I would run into linker multiple definition errors such like this:

<code>/usr/lib/gcc/x86_64-w64-mingw32/15.1.0/../../../../x86_64-w64-mingw32/bin/ld: mocs_compilation.cpp.obj (symbol from plugin):(.gnu.linkonce.t._ZN16JKQTPXYLineGraphD0Ev[_ZThn256_N16JKQTPXYLineGraphD0Ev]+0x0): multiple definition of `JKQTPXYLineGraph::~JKQTPXYLineGraph()'; graphDisplay.cpp.obj (symbol from plugin):(.gnu.linkonce.t._ZN16JKQTPXYLineGraphD0Ev[_ZThn128_N16JKQTPXYLineGraphD0Ev]+0x0): first defined here</code>

Where graphDisplay.cpp does not define a destructor, and rather just instantiates it.  This is resolved by adding an explicit destructor.

It is a little weird though that graphDisplay.cpp does the exact same as it does for lineGraph (creating and deleting them) for ScatterGraph which has no linkage issue here (but looking at the code has no specific destructor).