### PR TITLE
check Qt${QT_VERSION_MAJOR} at first

### DIFF
--- a/cmake/jkqtplotter_common_qtsettings.cmake
+++ b/cmake/jkqtplotter_common_qtsettings.cmake
@@ -4,7 +4,11 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+if(QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+else()
+    find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+endif()
 
 if(QT_VERSION_MAJOR LESS 5)
     message(FATAL_ERROR "Minimum supported Qt version is 5, but you are trying to compile against Qt${QT_VERSION_MAJOR}")


### PR DESCRIPTION
to respect an exported value of QT_VERSION_MAJOR and avoid conflict if both Qt5/Qt6 are installed

Reported in gentoo : https://bugs.gentoo.org/966047