### PR TITLE
Add fixed-mouse-position wheel zoom action (Google Maps style)

### DIFF
--- a/examples/user_interaction/test_user_interaction.cpp
+++ b/examples/user_interaction/test_user_interaction.cpp
@@ -212,8 +212,10 @@ TestUserInteraction::TestUserInteraction(QWidget *parent) :
     cmbMouseWheelAction->addItem("jkqtpmwaZoomByWheel");
     cmbMouseWheelAction->addItem("jkqtpmwaPanByWheel");
     cmbMouseWheelAction->addItem("jkqtpmwaZoomByWheelAndTrackpadPan");
+    cmbMouseWheelAction->addItem("jkqtpmwaZoomFixedMouseByWheel");
+    cmbMouseWheelAction->addItem("jkqtpmwaZoomFixedMouseByWheelAndTrackpadPan");
     cmbMouseWheelAction->addItem("NoAction");
-    cmbMouseWheelAction->setCurrentIndex(2);
+    cmbMouseWheelAction->setCurrentIndex(4);
     connect(cmbMouseWheelAction, SIGNAL(currentIndexChanged(int)), this, SLOT(setMouseWheelNoModAction(int)));
     setMouseWheelNoModAction(cmbMouseWheelAction->currentIndex());
 

--- a/lib/jkqtplotter/jkqtplotter.h
+++ b/lib/jkqtplotter/jkqtplotter.h
@@ -1376,6 +1376,7 @@ class JKQTPLOTTER_LIB_EXPORT JKQTPlotter: public QWidget {
 
         enum class WheelActionType {
             Zoom,
+            ZoomFixedMouse,
             Pan,
             None
         };

--- a/lib/jkqtplotter/jkqtptools.cpp
+++ b/lib/jkqtplotter/jkqtptools.cpp
@@ -397,6 +397,8 @@ JKQTPMouseWheelActions String2JKQTPMouseWheelActions(const QString &act)
     if (s=="jkqtpmwazoombywheel"||s=="zoombywheel" ||s=="zoom") return jkqtpmwaZoomByWheel;
     if (s=="jkqtpmwapanbywheel"||s=="panbywheel"||s=="pan") return jkqtpmwaPanByWheel;
     if (s=="jkqtpmwazoombywheelandtrackpadpan"||s=="zoombywheelortrackpan"||s=="zoomortrackpan") return jkqtpmwaZoomByWheelAndTrackpadPan;
+    if (s=="jkqtpmwazoomfixedmousebywheel"||s=="zoomfixedmousebywheel"||s=="zoomfixedmouse") return jkqtpmwaZoomFixedMouseByWheel;
+    if (s=="jkqtpmwazoomfixedmousebywheelandtrackpadpan"||s=="zoomfixedmousebywheelortrackpan"||s=="zoomfixedmouseortrackpan") return jkqtpmwaZoomFixedMouseByWheelAndTrackpadPan;
     return jkqtpmwaZoomByWheel;
 
 }
@@ -406,6 +408,8 @@ QString JKQTPMouseWheelActions2String(JKQTPMouseWheelActions act)
     if (act==jkqtpmwaZoomByWheel) return "zoom";
     if (act==jkqtpmwaPanByWheel) return "pan";
     if (act==jkqtpmwaZoomByWheelAndTrackpadPan) return "zoomortrackpan";
+    if (act==jkqtpmwaZoomFixedMouseByWheel) return "zoomfixedmouse";
+    if (act==jkqtpmwaZoomFixedMouseByWheelAndTrackpadPan) return "zoomfixedmouseortrackpan";
     return "unknown";
 }
 

--- a/lib/jkqtplotter/jkqtptools.h
+++ b/lib/jkqtplotter/jkqtptools.h
@@ -162,7 +162,7 @@ JKQTPLOTTER_LIB_EXPORT JKQTPMouseDoubleClickActions String2JKQTPMouseDoubleClick
  * \ingroup jkqtpplottersupprt
  */
 enum JKQTPMouseWheelActions {
-    jkqtpmwaZoomByWheel=0, /*!< \brief use the mouse-wheel for zooming, the new plot will be centered on the current mouse cursor position */
+    jkqtpmwaZoomByWheel=0, /*!< \brief use the mouse-wheel for zooming */
     jkqtpmwaPanByWheel, /*!< \brief use the mouse-wheel for panning the plot */
     jkqtpmwaZoomByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming (centered on mouse), and track-pad pan gesture recognition. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
     jkqtpmwaZoomFixedMouseByWheel, /*!< \brief use the mouse-wheel for zooming, while keeping the position under the mouse cursor fixed (Google Maps style zoom) */

--- a/lib/jkqtplotter/jkqtptools.h
+++ b/lib/jkqtplotter/jkqtptools.h
@@ -164,7 +164,7 @@ JKQTPLOTTER_LIB_EXPORT JKQTPMouseDoubleClickActions String2JKQTPMouseDoubleClick
 enum JKQTPMouseWheelActions {
     jkqtpmwaZoomByWheel=0, /*!< \brief use the mouse-wheel for zooming */
     jkqtpmwaPanByWheel, /*!< \brief use the mouse-wheel for panning the plot */
-    jkqtpmwaZoomByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming (centered on mouse), and track-pad pan gesture recognition. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
+    jkqtpmwaZoomByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming. In addition, this tries to recognize track-pad pan gestures and applies them. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
     jkqtpmwaZoomFixedMouseByWheel, /*!< \brief use the mouse-wheel for zooming, while keeping the position under the mouse cursor fixed (Google Maps style zoom) */
     jkqtpmwaZoomFixedMouseByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming with fixed mouse position, and track-pad pan gesture recognition. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
 };

--- a/lib/jkqtplotter/jkqtptools.h
+++ b/lib/jkqtplotter/jkqtptools.h
@@ -162,9 +162,11 @@ JKQTPLOTTER_LIB_EXPORT JKQTPMouseDoubleClickActions String2JKQTPMouseDoubleClick
  * \ingroup jkqtpplottersupprt
  */
 enum JKQTPMouseWheelActions {
-    jkqtpmwaZoomByWheel=0, /*!< \brief use the mouse-wheel for zooming */
+    jkqtpmwaZoomByWheel=0, /*!< \brief use the mouse-wheel for zooming, the new plot will be centered on the current mouse cursor position */
     jkqtpmwaPanByWheel, /*!< \brief use the mouse-wheel for panning the plot */
-    jkqtpmwaZoomByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming. In addition, this tries to recognize track-pad pan gestures and applies them. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
+    jkqtpmwaZoomByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming (centered on mouse), and track-pad pan gesture recognition. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
+    jkqtpmwaZoomFixedMouseByWheel, /*!< \brief use the mouse-wheel for zooming, while keeping the position under the mouse cursor fixed (Google Maps style zoom) */
+    jkqtpmwaZoomFixedMouseByWheelAndTrackpadPan, /*!< \brief use the mouse-wheel for zooming with fixed mouse position, and track-pad pan gesture recognition. \note This is needed, because Qt converts track-pad zoom AND pan gestures to wheelEvents, but does not provide the source. Therefore a heuristics is required to interpret both! */
 };
 
 /** \brief convert a JKQTPMouseWheelActions to a <a href="http://doc.qt.io/qt-5/qstring.html">QString</a>


### PR DESCRIPTION
First of all, thank you for creating and maintaining this wonderful library! I'm using JKQtPlotter for an internal tool at my company, and it has been incredibly helpful.

I wanted to add a new zoom mode for mouse wheel operation, so I'm submitting this PR. I would appreciate it if you could consider this contribution.

This adds new mouse wheel zoom actions that keep the position under the mouse cursor fixed during zooming (Google Maps style zoom behavior).

## Summary
  Add new mouse wheel zoom actions that keep the position under the mouse cursor fixed during zooming (Google Maps
  style zoom behavior).

  ## New Features
  - `jkqtpmwaZoomFixedMouseByWheel` - Zoom with fixed mouse position
  - `jkqtpmwaZoomFixedMouseByWheelAndTrackpadPan` - Same as above with trackpad pan gesture support

  ## Changes
  - Added new enum values to `JKQTPMouseWheelActions`
  - Added string conversion functions for the new actions
  - Implemented fixed-mouse-position zoom logic in `wheelEvent()`
  - Works for both plot area and axis-only zooming
  - Updated `user_interaction` example to demonstrate the new options

  ## Usage
  ```cpp
  plotter->registerMouseWheelAction(Qt::NoModifier,
      JKQTPMouseWheelActions::jkqtpmwaZoomFixedMouseByWheel);
```
  Behavior Comparison

  | Action                        | Behavior                                                 |
  |-------------------------------|----------------------------------------------------------|
  | jkqtpmwaZoomByWheel           | Mouse position becomes the center of the new view        |
  | jkqtpmwaZoomFixedMouseByWheel | Mouse position stays fixed on screen (Google Maps style) |