### PR TITLE
Fix image crop calculation by rounding endpoints independently (issue #160)

### DIFF
--- a/lib/jkqtplotter/graphs/jkqtpimage.cpp
+++ b/lib/jkqtplotter/graphs/jkqtpimage.cpp
@@ -187,7 +187,7 @@ void JKQTPImageBase::plotImage(JKQTPEnhancedPainter& painter, QImage& image, dou
             //qDebug()<<"p1  = "<<p1<< "    p2  = "<<p2;
             //qDebug()<<"pp1 = "<<pp1<<"    pp2 = "<<pp2;
             QPointF ps1(floor((pix_plot_topleft.x()-pix_topelft.x())/pixwidth), floor((pix_plot_topleft.y()-pix_topelft.y())/pixheight));
-            QPointF ps2=ps1+QPointF(ceil(fabs(pix_plot_bottomright.x()-pix_plot_topleft.x())/pixwidth), ceil(fabs(pix_plot_bottomright.y()-pix_plot_topleft.y())/pixheight));
+            QPointF ps2(ceil((pix_plot_bottomright.x()-pix_topelft.x())/pixwidth), ceil((pix_plot_bottomright.y()-pix_topelft.y())/pixheight));
             if (ps1.x()<0) ps1.setX(0);
             if (ps1.y()<0) ps1.setY(0);
             if (ps2.x()>image.width()) ps2.setX(image.width());


### PR DESCRIPTION
## Summary

Fixes #160
When zooming into an image, pixels at the edge could disappear due to incorrect crop rectangle calculation.

## Problem
The source rectangle endpoint (`ps2`) was calculated by adding a rounded width to the starting point:
```cpp
ps2 = ps1 + QPointF(ceil(width), ceil(height))
```
This is mathematically incorrect because floor(start) + ceil(width) ≠ ceil(end) in general.
Example: For a range from 4.6 to 5.4, endpoint ps2 is
  - Before: floor(4.6) + ceil(0.8) = 4 + 1 = 5 
  - After: ceil(5.4) = 6

## Solution
Calculate endpoints independently by rounding them from their absolute positions:

```cpp
  ps1 = floor(start)
  ps2 = ceil(end)
```
This ensures all pixels within the visible range are correctly included in the crop.